### PR TITLE
Change whitelist default behavior on non-match

### DIFF
--- a/plugin/configloader.go
+++ b/plugin/configloader.go
@@ -91,16 +91,6 @@ func (p *Plugin) getConfigForTree(ctx context.Context, req *request, dir string,
 	return configData, nil
 }
 
-// getConfigDefault reads just the 'drone.yml' from the root of the repo -- the default behavior of drone
-func (p *Plugin) getConfigDefault(ctx context.Context, req *request) (configData string, err error) {
-	// download file from git
-	fileContent, _, err := p.getDroneConfig(ctx, req, req.Repo.Config)
-	if err != nil {
-		return "", err
-	}
-	return fileContent, nil
-}
-
 // getDroneConfig downloads a drone config and validates it
 func (p *Plugin) getDroneConfig(ctx context.Context, req *request, file string) (configData string, critical bool, err error) {
 	fileContent, err := p.getScmFile(ctx, req, file)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -66,13 +66,8 @@ func (p *Plugin) Find(ctx context.Context, droneRequest *config.Request) (*drone
 
 	// make sure this plugin is enabled for the requested repo slug
 	if ok := p.whitelisted(&req); !ok {
-		// use the default (top-most) drone.yml
-		configData, err := p.getConfigDefault(ctx, &req)
-		if err != nil {
-			return nil, err
-		}
-
-		return &drone.Config{Data: configData}, nil
+		// do the default behavior by returning nil, nil
+		return nil, nil
 	}
 
 	// get changed files

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -172,11 +172,12 @@ func TestMatchEnable(t *testing.T) {
 
 	type scenario struct {
 		file string
-		want string
+		want *drone.Config
 	}
 
-	noMatchWant := "kind: pipeline\nname: default\n\nsteps:\n- name: frontend\n  image: node\n  commands:\n  - npm install\n  - npm test\n\n- name: backend\n  image: golang\n  commands:\n  - go build\n  - go test\n"
-	matchWant := "---\nkind: pipeline\nname: default\n\nsteps:\n- name: build\n  image: golang\n  commands:\n  - go build\n  - go test -short\n\n- name: integration\n  image: golang\n  commands:\n  - go test -v\n"
+	matchWant := &drone.Config{
+		Data: "---\nkind: pipeline\nname: default\n\nsteps:\n- name: build\n  image: golang\n  commands:\n  - go build\n  - go test -short\n\n- name: integration\n  image: golang\n  commands:\n  - go test -v\n",
+	}
 
 	scenarios := map[string]scenario{
 		// matches all repos for this plugin
@@ -187,7 +188,7 @@ func TestMatchEnable(t *testing.T) {
 		// matches no repos for this plugin
 		"MatchNone": {
 			file: "testdata/regex/matchnone",
-			want: noMatchWant,
+			want: nil,
 		},
 		// matches all repos for this plugin. specified file with match rules does not exist
 		"FileError": {
@@ -216,8 +217,14 @@ func TestMatchEnable(t *testing.T) {
 				return
 			}
 
-			if got := droneConfig.Data; s.want != got {
-				t.Errorf("Want %q got %q", s.want, got)
+			if droneConfig != nil {
+				if got := droneConfig.Data; s.want.Data != got {
+					t.Errorf("Want %q got %q", s.want, got)
+				}
+			} else {
+				if got := droneConfig; s.want != got {
+					t.Errorf("Want %q got %q", s.want, got)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Drone will do the default behavior if/when a plugin
returns nil,nil. Changed the plugin.go logic to
comply with this when whitelist is used

Reference:
https://github.com/drone/boilr-config/blob/master/template/plugin/plugin.go#L54-L57