### PR TITLE
Fix #22 - 3 dots in yaml are replaced

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -99,13 +99,14 @@ func (p *Plugin) Find(ctx context.Context, droneRequest *config.Request) (*drone
 	}
 
 	// cleanup
-	configData = strings.ReplaceAll(configData, "...", "")
+	configData = string(removeDocEndRegex.ReplaceAllString(configData, ""))
 	configData = string(dedupRegex.ReplaceAll([]byte(configData), []byte("---")))
 
 	return &drone.Config{Data: configData}, nil
 }
 
 var dedupRegex = regexp.MustCompile(`(?ms)(---[\s]*){2,}`)
+var removeDocEndRegex = regexp.MustCompile(`(?ms)^(\.\.\.)$`)
 
 // droneConfigAppend concats multiple 'drone.yml's to a multi-machine pipeline
 // see https://docs.drone.io/user-guide/pipeline/multi-machine/


### PR DESCRIPTION
Yaml end of document separator (...) is also
valid for some commands such as (go test ./...).

Changed the code use a regex to find the end
of document separator and ignore any other
occurences of 3 dots.