### PR TITLE
Fix for `@cron` triggers

### DIFF
--- a/plugin/configloader.go
+++ b/plugin/configloader.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"path"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -15,14 +14,8 @@ func (p *Plugin) getConfigForChanges(ctx context.Context, req *request, changedF
 	configData = ""
 	cache := map[string]bool{}
 	for _, file := range changedFiles {
-		if !strings.HasPrefix(file, "/") {
-			file = "/" + file
-		}
-
-		done := false
 		dir := file
-		for !done {
-			done = bool(dir == "/")
+		for dir != "." {
 			dir = path.Join(dir, "..")
 			file := path.Join(dir, req.Repo.Config)
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -84,10 +84,10 @@ func (p *Plugin) Find(ctx context.Context, droneRequest *config.Request) (*drone
 		configData, err = p.getConfigForChanges(ctx, &req, changedFiles)
 	} else if req.Build.Trigger == "@cron" {
 		logrus.Warnf("%s @cron, rebuilding all", req.UUID)
-		configData, err = p.getConfigForTree(ctx, &req, "/", 0)
+		configData, err = p.getConfigForTree(ctx, &req, "", 0)
 	} else if p.fallback {
 		logrus.Warnf("%s no changed files and fallback enabled, rebuilding all", req.UUID)
-		configData, err = p.getConfigForTree(ctx, &req, "/", 0)
+		configData, err = p.getConfigForTree(ctx, &req, "", 0)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Git repo paths do not start with "/"

Prior to this fix, it was possible that a `@cron` associated with the non-default branch would return the incorrect config data.

---

This PR fixes the following error;

given a repo, with a default (typically `master`) branch, that contains some tree;
```shell
$ tree -a .                                                                        
.
└── README.md

0 directories, 1 file
```

and a `@cron` established for the same repo, configured for branch `foo`, which contains a different tree;

```shell
$ tree -a .                                                                   
.
├── component_a
│   └── .drone.yml
├── component_b
│   └── .drone.yml
└── README.md

2 directories, 3 files
```

if the latest commit ref for `foo` is `abcde12345`, and assuming a GitHub repository, the existing code would call `repos/{slug}/contents//?ref=abcde12345` which would return the tree for the default branch. This is due to the extra `/` before the query string in the request. See the default when `ref` is omitted per the documentation - https://developer.github.com/v3/repos/contents/#get-contents

The expected behavior for a `@cron` (and with drone-tree-config) is to walk the entire tree for the branch configured in Drone.

---

* In addition this PR applies the same fix when the change set does not include any changed files.
* Last, it removes the `/` prefix which was applied in the code for `plugin.getConfigForChanges(...)`

---

Note: I have not tested this change with the bitbucket and gitlab SCM's. This said, the following documentation (and code) suggests that `/` as a prefix is also not expected, for them;

* The API called in the bitbucket integration -- https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bnode%7D/%7Bpath%7D
* The API called in the gitlab integration -- https://docs.gitlab.com/ce/api/repositories.html#list-repository-tree
* Current code for gitlab integration which removes the `/` prefix -- https://github.com/bitsbeats/drone-tree-config/blob/master/plugin/scm_clients/gitlab_client.go#L127
