### PR TITLE
Fixes #17 diff error when repo's default branch is not `master`

### DIFF
--- a/plugin/scm.go
+++ b/plugin/scm.go
@@ -57,7 +57,7 @@ func (p *Plugin) getScmChanges(ctx context.Context, req *request) ([]string, err
 		after := req.Build.After
 
 		// check for branch pr
-		if commitBranch != repoBranch {
+		if strings.HasPrefix(req.Build.Ref, "refs/pull/") && commitBranch != repoBranch {
 			before = repoBranch
 		}
 


### PR DESCRIPTION
Check if ref includes `refs/pull/` in addition to checking if commitBranch is not equal to repository's default branch