### PR TITLE
Do not ignore paginated reponse from github PR Listfiles API

### DIFF
--- a/plugin/scm_clients/github_client.go
+++ b/plugin/scm_clients/github_client.go
@@ -3,6 +3,7 @@ package scm_clients
 import (
 	"context"
 	"fmt"
+
 	"github.com/drone/drone-go/drone"
 	"github.com/google/go-github/github"
 	"github.com/google/uuid"
@@ -38,13 +39,22 @@ func NewGitHubClient(ctx context.Context, uuid uuid.UUID, server string, token s
 
 func (s GithubClient) ChangedFilesInPullRequest(ctx context.Context, pullRequestID int) ([]string, error) {
 	var changedFiles []string
-	files, _, err := s.listFiles(ctx, pullRequestID)
-	if err != nil {
-		return nil, err
+	opts := &github.ListOptions{}
+
+	for {
+		files, resp, err := s.listFiles(ctx, pullRequestID, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			changedFiles = append(changedFiles, *file.Filename)
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
-	for _, file := range files {
-		changedFiles = append(changedFiles, *file.Filename)
-	}
+
 	return changedFiles, nil
 }
 
@@ -91,9 +101,8 @@ func (s GithubClient) GetFileListing(ctx context.Context, path string, commitRef
 	return result, err
 }
 
-func (s GithubClient) listFiles(ctx context.Context, number int) (
+func (s GithubClient) listFiles(ctx context.Context, number int, opts *github.ListOptions) (
 	[]*github.CommitFile, *github.Response, error) {
-	opts := &github.ListOptions{}
 	return s.delegate.PullRequests.ListFiles(ctx, s.repo.Namespace, s.repo.Name, number, opts)
 }
 


### PR DESCRIPTION
Fix issue where only the first page (30 files max) was considered

---

Ref: We call this API and it could return a paginated response -- https://developer.github.com/v3/pulls/#list-pull-requests-files