### PR TITLE
Reuse the github client delegate

### DIFF
--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -18,11 +18,16 @@ var noContext = context.Background()
 
 const mockToken = "7535706b694c63526c6e4f5230374243"
 
+var ts *httptest.Server
+
+func TestMain(m *testing.M) {
+	ts = httptest.NewServer(testMux())
+	defer ts.Close()
+	os.Exit(m.Run())
+}
+
 // test commit
 func TestPlugin(t *testing.T) {
-	ts := httptest.NewServer(testMux())
-	defer ts.Close()
-
 	req := &config.Request{
 		Build: drone.Build{
 			Before: "2897b31ec3a1b59279a08a8ad54dc360686327f7",
@@ -55,9 +60,6 @@ func TestPlugin(t *testing.T) {
 }
 
 func TestConcat(t *testing.T) {
-	ts := httptest.NewServer(testMux())
-	defer ts.Close()
-
 	req := &config.Request{
 		Build: drone.Build{
 			Before: "2897b31ec3a1b59279a08a8ad54dc360686327f7",
@@ -91,9 +93,6 @@ func TestConcat(t *testing.T) {
 }
 
 func TestPullRequest(t *testing.T) {
-	ts := httptest.NewServer(testMux())
-	defer ts.Close()
-
 	req := &config.Request{
 		Build: drone.Build{
 			Fork: "octocat/dronetest",
@@ -125,9 +124,6 @@ func TestPullRequest(t *testing.T) {
 }
 
 func TestCron(t *testing.T) {
-	ts := httptest.NewServer(testMux())
-	defer ts.Close()
-
 	req := &config.Request{
 		Build: drone.Build{
 			After:   "8ecad91991d5da985a2a8dd97cc19029dc1c2899",
@@ -158,9 +154,6 @@ func TestCron(t *testing.T) {
 }
 
 func TestMatchEnable(t *testing.T) {
-	ts := httptest.NewServer(testMux())
-	defer ts.Close()
-
 	req := &config.Request{
 		Build: drone.Build{
 			Before: "2897b31ec3a1b59279a08a8ad54dc360686327f7",
@@ -237,9 +230,6 @@ func TestMatchEnable(t *testing.T) {
 }
 
 func TestCronConcat(t *testing.T) {
-	ts := httptest.NewServer(testMux())
-	defer ts.Close()
-
 	req := &config.Request{
 		Build: drone.Build{
 			After:   "8ecad91991d5da985a2a8dd97cc19029dc1c2899",

--- a/plugin/scm_clients/github_client.go
+++ b/plugin/scm_clients/github_client.go
@@ -3,6 +3,8 @@ package scm_clients
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	"github.com/drone/drone-go/drone"
 	"github.com/google/go-github/github"
 	"github.com/google/uuid"
@@ -15,25 +17,49 @@ type GithubClient struct {
 	repo     drone.Repo
 }
 
+var (
+	lock sync.Mutex
+	ghClient *github.Client
+)
+
+// NewGitHubClient creates a GithubClient which can be used to send requests to the Github API
 func NewGitHubClient(ctx context.Context, uuid uuid.UUID, server string, token string, repo drone.Repo) (ScmClient, error) {
-	trans := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	))
-	var client *github.Client
-	if server == "" {
-		client = github.NewClient(trans)
-	} else {
-		var err error
-		client, err = github.NewEnterpriseClient(server, server, trans)
-		if err != nil {
-			logrus.Errorf("%s Unable to connect to Github: '%v'", uuid, err)
-			return nil, err
-		}
+	client, err := getClientDelegate(ctx, server, token)
+	if err != nil {
+		logrus.Errorf("%s Unable to connect to Github: '%v'", uuid, err)
+		return nil, err
 	}
+
 	return GithubClient{
 		delegate: client,
 		repo:     repo,
 	}, nil
+}
+
+func getClientDelegate(ctx context.Context, server string, token string) (*github.Client, error) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	// return pre-existing client delegate
+	if ghClient != nil {
+		return ghClient, nil
+	}
+
+	// create a new one
+	trans := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	))
+	if server == "" {
+		ghClient = github.NewClient(trans)
+	} else {
+		var err error
+		ghClient, err = github.NewEnterpriseClient(server, server, trans)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ghClient, nil
 }
 
 func (s GithubClient) ChangedFilesInPullRequest(ctx context.Context, pullRequestID int) ([]string, error) {

--- a/plugin/scm_clients/github_client_test.go
+++ b/plugin/scm_clients/github_client_test.go
@@ -1,21 +1,28 @@
 package scm_clients
 
 import (
-	"github.com/drone/drone-go/drone"
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/drone/drone-go/drone"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 )
 
 const mockGithubToken = "7535706b694c63526c6e4f5230374243"
 
-func TestGithubClient_GetFileContents(t *testing.T) {
-	ts := httptest.NewServer(testMuxGithub())
+var ts *httptest.Server
+
+func TestMain(m *testing.M) {
+	ts = httptest.NewServer(testMuxGithub())
 	defer ts.Close()
+	os.Exit(m.Run())
+}
+
+func TestGithubClient_GetFileContents(t *testing.T) {
 	client, err := createGithubClient(ts.URL)
 	if err != nil {
 		t.Error(err)
@@ -25,8 +32,6 @@ func TestGithubClient_GetFileContents(t *testing.T) {
 }
 
 func TestGithubClient_ChangedFilesInDiff(t *testing.T) {
-	ts := httptest.NewServer(testMuxGithub())
-	defer ts.Close()
 	client, err := createGithubClient(ts.URL)
 	if err != nil {
 		t.Error(err)
@@ -36,8 +41,6 @@ func TestGithubClient_ChangedFilesInDiff(t *testing.T) {
 }
 
 func TestGithubClient_ChangedFilesInPullRequest(t *testing.T) {
-	ts := httptest.NewServer(testMuxGithub())
-	defer ts.Close()
 	client, err := createGithubClient(ts.URL)
 	if err != nil {
 		t.Error(err)
@@ -48,8 +51,6 @@ func TestGithubClient_ChangedFilesInPullRequest(t *testing.T) {
 }
 
 func TestGithubClient_GetFileListing(t *testing.T) {
-	ts := httptest.NewServer(testMuxGithub())
-	defer ts.Close()
 	client, err := createGithubClient(ts.URL)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Changed the github_client.NewGitHubClient implementation
such that it re-uses the same github.Client for all
requests.

There is no need to recreate a new delegate for every request.
The internal go-github library calls NewRequest using the
delegate receiver for all calls. Furthermore, the same
credentials (token) and sever (endpoint) are used for
all github requests throughout this project.

--

Also, in this change set -- Updated `github_client_test` and main `plugin_test ` code to use a fixed `testMux` across all tests in the same file. This change ensures "the contract" -- a single `server` and `token` will be configured --  is also true for the tests. 

Notable limitation:  Per this implementation, "the contract" is not enforced or checked within `github_client.go` .. Calling code such as `plugin.go` needs to comply by never passing a different `server` or `token` -- which now that I've updated the tests, is the case everywhere in this project.  I'm happy to add a check to detect a change to the `server` or `token` which is passed, if there is a favorable view for it.