### PR TITLE
Add ability to leverage an in memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently supports
 * `PLUGIN_ADDRESS`: Listen address for the plugins webserver. Defaults to `:3000`.
 * `PLUGIN_SECRET`: Shared secret with drone. You can generate the token using `openssl rand -hex 16`.
 * `PLUGIN_ALLOW_LIST_FILE`: (Optional) Path to regex pattern file. Matches the repo slug(s) against a list of regex patterns. Defaults to `""`, match everything.
+* `PLUGIN_CACHE_TTL`: (Optional) Cache entry time to live value. When defined and greater than `0s`, enables in memory caching for request/response pairs.   
 * `PLUGIN_CONSIDER_FILE`: (Optional) Consider file name. Only consider the `.drone.yml` files listed in this file. When defined, all enabled repos must contain a consider file.
 
 Backend specific options
@@ -130,9 +131,9 @@ File: drone-tree-config-matchfile:
  If a `PLUGIN_CONSIDER_FILE` is defined, drone-tree-config will first read the content of the target file and will only consider
  the `.drone.yml` files specified, when matching.
 
-Depending on the size and the complexity of the repository, using a "consider file" can
-significantly reduce the number of API calls made to the provider (github, bitbucket, other). The reduction in API calls
-reduces the risk of being rate limited and can result in less processing time for drone-tree-config.
+Depending on the size and the complexity of the repository, using a "consider file" can significantly reduce the number 
+of API calls made to the provider (github, bitbucket, other). The reduction in API calls reduces the risk of being rate 
+limited and can result in less processing time for drone-tree-config.
 
 Given the config;
 
@@ -165,3 +166,18 @@ bar/.drone.yml
 The downside of a "consider file" is that it has to be kept in sync. As a suggestion, to help with this, a step can be
 added to each `.drone.yml` which verifies the "consider file" is in sync with the actual content of the repo. For
 example, this can be accomplished by comparing the output of `find ./ -name .drone.yml` with the content of the "consider file".
+
+#### Caching
+
+If a `PLUGIN_CACHE_TTL` is defined, drone-tree-config will leverage an in memory cache to match the inbound requests
+against ones that exist in the cache. When a match is found, the cached response is returned. Cached entries are 
+expired and removed when their per-entry TTL is reached.
+
+Example (expire after 30 minutes);
+```yaml
+ - PLUGIN_CACHE_TTL=30m
+```
+
+Depending on the size and the complexity of the repository, using a cache can significantly reduce the number of API 
+calls made to the provider (github, bitbucket, other). The reduction in API calls reduces the risk of being rate 
+limited and can result in less processing time for drone-tree-config.

--- a/cmd/drone-tree-config/main.go
+++ b/cmd/drone-tree-config/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/bitsbeats/drone-tree-config/plugin"
 
@@ -12,21 +13,22 @@ import (
 
 type (
 	spec struct {
-		AllowListFile       string `envconfig:"PLUGIN_ALLOW_LIST_FILE"`
-		Concat              bool   `envconfig:"PLUGIN_CONCAT"`
-		MaxDepth            int    `envconfig:"PLUGIN_MAXDEPTH" default:"2"`
-		Fallback            bool   `envconfig:"PLUGIN_FALLBACK"`
-		Debug               bool   `envconfig:"PLUGIN_DEBUG"`
-		Address             string `envconfig:"PLUGIN_ADDRESS" default:":3000"`
-		Secret              string `envconfig:"PLUGIN_SECRET"`
-		Server              string `envconfig:"SERVER" default:"https://api.github.com"`
-		GitHubToken         string `envconfig:"GITHUB_TOKEN"`
-		GitLabToken         string `envconfig:"GITLAB_TOKEN"`
-		GitLabServer        string `envconfig:"GITLAB_SERVER" default:"https://gitlab.com"`
-		BitBucketAuthServer string `envconfig:"BITBUCKET_AUTH_SERVER"`
-		BitBucketClient     string `envconfig:"BITBUCKET_CLIENT"`
-		BitBucketSecret     string `envconfig:"BITBUCKET_SECRET"`
-		ConsiderFile        string `envconfig:"PLUGIN_CONSIDER_FILE"`
+		AllowListFile       string        `envconfig:"PLUGIN_ALLOW_LIST_FILE"`
+		Concat              bool          `envconfig:"PLUGIN_CONCAT"`
+		MaxDepth            int           `envconfig:"PLUGIN_MAXDEPTH" default:"2"`
+		Fallback            bool          `envconfig:"PLUGIN_FALLBACK"`
+		Debug               bool          `envconfig:"PLUGIN_DEBUG"`
+		Address             string        `envconfig:"PLUGIN_ADDRESS" default:":3000"`
+		Secret              string        `envconfig:"PLUGIN_SECRET"`
+		Server              string        `envconfig:"SERVER" default:"https://api.github.com"`
+		GitHubToken         string        `envconfig:"GITHUB_TOKEN"`
+		GitLabToken         string        `envconfig:"GITLAB_TOKEN"`
+		GitLabServer        string        `envconfig:"GITLAB_SERVER" default:"https://gitlab.com"`
+		BitBucketAuthServer string        `envconfig:"BITBUCKET_AUTH_SERVER"`
+		BitBucketClient     string        `envconfig:"BITBUCKET_CLIENT"`
+		BitBucketSecret     string        `envconfig:"BITBUCKET_SECRET"`
+		ConsiderFile        string        `envconfig:"PLUGIN_CONSIDER_FILE"`
+		CacheTTL            time.Duration `envconfig:"PLUGIN_CACHE_TTL"`
 	}
 )
 
@@ -66,6 +68,7 @@ func main() {
 			plugin.WithGitlabToken(spec.GitLabToken),
 			plugin.WithGitlabServer(spec.GitLabServer),
 			plugin.WithConsiderFile(spec.ConsiderFile),
+			plugin.WithCacheTTL(spec.CacheTTL),
 		),
 		spec.Secret,
 		logrus.StandardLogger(),

--- a/plugin/cache.go
+++ b/plugin/cache.go
@@ -1,0 +1,112 @@
+package plugin
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/drone/drone-go/drone"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	msgCacheHit    = "%s config-cache found entry for %s"
+	msgCacheExpire = "config-cache expired entry for %s"
+	msgCacheAdd    = "%s config-cache added entry for %s"
+)
+
+// configCache is used to cache config responses on a per request basis
+type configCache struct {
+	syncMap sync.Map
+}
+
+// cacheKey holds the unique key details which are associated with the config request
+type cacheKey struct {
+	slug    string
+	ref     string
+	before  string
+	after   string
+	event   string
+	trigger string
+	author  string
+}
+
+// cacheEntry holds the response and ttl for a config request
+type cacheEntry struct {
+	config string
+	error  error
+	ttl    *time.Timer
+}
+
+// newCacheEntry creates a new cacheEntry using the config string and error provided. The returned struct will have a
+// nil ttl value -- it will be established when a entry is added to the cache via the add function.
+func newCacheEntry(config string, error error) *cacheEntry {
+	entry := &cacheEntry{
+		config: config,
+		error:  error,
+	}
+	return entry
+}
+
+// newCacheKey creates a new cacheKey for the provided request.
+func newCacheKey(req *request) cacheKey {
+	ck := cacheKey{
+		slug:    req.Repo.Slug,
+		ref:     req.Build.Ref,
+		before:  req.Build.Before,
+		after:   req.Build.After,
+		event:   req.Build.Event,
+		author:  req.Build.Author,
+		trigger: req.Build.Trigger,
+	}
+	return ck
+}
+
+// add an entry to the cache
+func (c *configCache) add(uuid uuid.UUID, key cacheKey, entry *cacheEntry, ttl time.Duration) {
+	logrus.Infof(msgCacheAdd, uuid, fmt.Sprintf("%+v", key))
+
+	entry.ttl = time.AfterFunc(ttl, func() {
+		c.expire(key)
+	})
+
+	c.syncMap.Store(key, entry)
+}
+
+// expire is typically called internally via a time.Afterfunc
+func (c *configCache) expire(key cacheKey) {
+	logrus.Infof(msgCacheExpire, fmt.Sprintf("%+v", key))
+
+	if entry, _ := c.syncMap.Load(key); entry != nil {
+		entry.(*cacheEntry).ttl.Stop()
+		c.syncMap.Delete(key)
+	}
+}
+
+// retrieve an entry from the cache, if it exists
+func (c *configCache) retrieve(uuid uuid.UUID, key cacheKey) (*cacheEntry, bool) {
+	entry, exists := c.syncMap.Load(key)
+	if exists {
+		logrus.Infof(msgCacheHit, uuid, fmt.Sprintf("%+v", key))
+		return entry.(*cacheEntry), true
+	}
+
+	return nil, false
+}
+
+// cacheAndReturn caches the result (if enabled) and returns the (drone.Config, error) that should be
+// returned to the Find request.
+func (p *Plugin) cacheAndReturn(uuid uuid.UUID, key cacheKey, entry *cacheEntry) (*drone.Config, error) {
+	var config *drone.Config
+	if entry.config != "" {
+		config = &drone.Config{Data: entry.config}
+	}
+
+	// cache the config before we return it, if enabled
+	if p.cacheTTL > 0 {
+		p.cache.add(uuid, key, entry, p.cacheTTL)
+	}
+
+	return config, entry.error
+}

--- a/plugin/options.go
+++ b/plugin/options.go
@@ -1,5 +1,7 @@
 package plugin
 
+import "time"
+
 // WithServer configures with a custom SCM server
 func WithServer(server string) func(*Plugin) {
 	return func(p *Plugin) {
@@ -82,5 +84,12 @@ func WithAllowListFile(file string) func(*Plugin) {
 func WithConsiderFile(considerFile string) func(*Plugin) {
 	return func(p *Plugin) {
 		p.considerFile = considerFile
+	}
+}
+
+// WithCacheTTL enables request/response caching and the specified TTL for each entry
+func WithCacheTTL(ttl time.Duration) func(*Plugin) {
+	return func(p *Plugin) {
+		p.cacheTTL = ttl
 	}
 }


### PR DESCRIPTION
When drone-tree-config returns a "multi-machine"
pipeline to drone, drone can in-turn hit
drone-tree-config again for each stage of the
"multi-machine" pipeline..

This change set gives drone-tree-config the
ability to respond to such "duplicate"
requests via an in memory cache.

As a result, the provider API is not leveraged
every time and the likelihood of being rate 
limited is reduced

---
Example output of the new test;

```shell
=== RUN   TestCache
time="2021-01-19T13:37:30-08:00" level=info msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 foosinn/dronetest started"
time="2021-01-19T13:37:30-08:00" level=info msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 match: foosinn/dronetest"
time="2021-01-19T13:37:30-08:00" level=debug msg="drone-tree-config environment" after=8ecad91991d5da985a2a8dd97cc19029dc1c2899 before= branch= ref= slug=foosinn/dronetest trigger=@cron
time="2021-01-19T13:37:30-08:00" level=warning msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 @cron, rebuilding all"
time="2021-01-19T13:37:30-08:00" level=warning msg="recursively scanning for config files with max depth 2"
time="2021-01-19T13:37:30-08:00" level=debug msg="Repositories.CompareCommits 200: http://127.0.0.1:45879/api/v3/repos/foosinn/dronetest/contents/?ref=8ecad91991d5da985a2a8dd97cc19029dc1c2899"
time="2021-01-19T13:37:30-08:00" level=debug msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 checking foosinn/dronetest .drone.yml"
time="2021-01-19T13:37:30-08:00" level=debug msg="Repositories.CompareCommits 200: http://127.0.0.1:45879/api/v3/repos/foosinn/dronetest/contents/.drone.yml?ref=8ecad91991d5da985a2a8dd97cc19029dc1c2899"
time="2021-01-19T13:37:30-08:00" level=info msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 found foosinn/dronetest .drone.yml"
time="2021-01-19T13:37:30-08:00" level=debug msg="Repositories.CompareCommits 200: http://127.0.0.1:45879/api/v3/repos/foosinn/dronetest/contents/afolder?ref=8ecad91991d5da985a2a8dd97cc19029dc1c2899"
time="2021-01-19T13:37:30-08:00" level=debug msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 checking foosinn/dronetest afolder/.drone.yml"
time="2021-01-19T13:37:30-08:00" level=debug msg="Repositories.CompareCommits 200: http://127.0.0.1:45879/api/v3/repos/foosinn/dronetest/contents/afolder/.drone.yml?ref=8ecad91991d5da985a2a8dd97cc19029dc1c2899"
time="2021-01-19T13:37:30-08:00" level=info msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 found foosinn/dronetest afolder/.drone.yml"
time="2021-01-19T13:37:30-08:00" level=debug msg="Repositories.CompareCommits 200: http://127.0.0.1:45879/api/v3/repos/foosinn/dronetest/contents/afolder/abfolder?ref=8ecad91991d5da985a2a8dd97cc19029dc1c2899"
time="2021-01-19T13:37:30-08:00" level=info msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 config-cache added entry for {slug:foosinn/dronetest ref: before: after:8ecad91991d5da985a2a8dd97cc19029dc1c2899 event: trigger:@cron author:}"
time="2021-01-19T13:37:30-08:00" level=info msg="2e5559eb-b50c-4144-b177-bdccd6fdbcd1 finished"
time="2021-01-19T13:37:30-08:00" level=info msg="d145c939-80c7-4883-813b-fca40b1c9f7a config-cache found entry for {slug:foosinn/dronetest ref: before: after:8ecad91991d5da985a2a8dd97cc19029dc1c2899 event: trigger:@cron author:}"
time="2021-01-19T13:37:30-08:00" level=info msg="0a662f3e-9177-4e2f-8f02-bb0854a4f9a3 foosinn/dronetest started"
time="2021-01-19T13:37:30-08:00" level=info msg="0a662f3e-9177-4e2f-8f02-bb0854a4f9a3 match: foosinn/dronetest"
time="2021-01-19T13:37:30-08:00" level=debug msg="drone-tree-config environment" after=8ecad91991d5da985a2a8dd97cc19029dc1c2899 before= branch= ref= slug=foosinn/dronetest trigger=@cron
time="2021-01-19T13:37:30-08:00" level=info msg="0a662f3e-9177-4e2f-8f02-bb0854a4f9a3 config-cache found entry for {slug:foosinn/dronetest ref: before: after:8ecad91991d5da985a2a8dd97cc19029dc1c2899 event: trigger:@cron author:}"
time="2021-01-19T13:37:30-08:00" level=info msg="0a662f3e-9177-4e2f-8f02-bb0854a4f9a3 finished"
time="2021-01-19T13:37:30-08:00" level=info msg="d145c939-80c7-4883-813b-fca40b1c9f7a config-cache found entry for {slug:foosinn/dronetest ref: before: after:8ecad91991d5da985a2a8dd97cc19029dc1c2899 event: trigger:@cron author:}"
time="2021-01-19T13:37:30-08:00" level=info msg="config-cache expired entry for {slug:foosinn/dronetest ref: before: after:8ecad91991d5da985a2a8dd97cc19029dc1c2899 event: trigger:@cron author:}"
--- PASS: TestCache (0.00s)
PASS
```