### PR TITLE
Always fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Currently supports
 
 * `PLUGIN_CONCAT`: Concats all found configs to a multi-machine build. Defaults to `false`.
 * `PLUGIN_FALLBACK`: Rebuild all .drone.yml if no changes where made. Defaults to `false`.
-* `PLUGIN_MAXDEPTH`: Max depth to search for `.drone.yml`, only active in fallback mode. Defaults to `2` (would still find `/a/b/.drone.yml`).
+* `PLUGIN_ALWAYS_FALLBACK`: Always rebuild all .drone.yml. Useful when repository has a global dependency, like executing tests on all projects in repo before building individual artefacts. Defaults to `false`.
+* `PLUGIN_MAXDEPTH`: Max depth to search for `.drone.yml`, only active in fallback and always fallback modes or when pipeline was triggered by cron. Defaults to `2` (would still find `/a/b/.drone.yml`).
 * `PLUGIN_DEBUG`: Set this to `true` to enable debug messages.
 * `PLUGIN_ADDRESS`: Listen address for the plugins webserver. Defaults to `:3000`.
 * `PLUGIN_SECRET`: Shared secret with drone. You can generate the token using `openssl rand -hex 16`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently supports
 
 * `PLUGIN_CONCAT`: Concats all found configs to a multi-machine build. Defaults to `false`.
 * `PLUGIN_FALLBACK`: Rebuild all .drone.yml if no changes where made. Defaults to `false`.
-* `PLUGIN_ALWAYS_FALLBACK`: Always rebuild all .drone.yml. Useful when repository has a global dependency, like executing tests on all projects in repo before building individual artefacts. Defaults to `false`.
+* `PLUGIN_ALWAYS_RUN_ALL`: Always rebuild all .drone.yml. Useful when repository has a global dependency, like executing tests on all projects in repo before building individual artefacts. Defaults to `false`.
 * `PLUGIN_MAXDEPTH`: Max depth to search for `.drone.yml`, only active in fallback and always fallback modes or when pipeline was triggered by cron. Defaults to `2` (would still find `/a/b/.drone.yml`).
 * `PLUGIN_DEBUG`: Set this to `true` to enable debug messages.
 * `PLUGIN_ADDRESS`: Listen address for the plugins webserver. Defaults to `:3000`.

--- a/cmd/drone-tree-config/main.go
+++ b/cmd/drone-tree-config/main.go
@@ -16,7 +16,7 @@ type (
 		AllowListFile       string        `envconfig:"PLUGIN_ALLOW_LIST_FILE"`
 		Concat              bool          `envconfig:"PLUGIN_CONCAT"`
 		MaxDepth            int           `envconfig:"PLUGIN_MAXDEPTH" default:"2"`
-		AlwaysFallback      bool          `envconfig:"PLUGIN_ALWAYS_FALLBACK"`
+		AlwaysRunAll        bool          `envconfig:"PLUGIN_ALWAYS_RUN_ALL"`
 		Fallback            bool          `envconfig:"PLUGIN_FALLBACK"`
 		Debug               bool          `envconfig:"PLUGIN_DEBUG"`
 		Address             string        `envconfig:"PLUGIN_ADDRESS" default:":3000"`
@@ -59,7 +59,7 @@ func main() {
 		plugin.New(
 			plugin.WithConcat(spec.Concat),
 			plugin.WithFallback(spec.Fallback),
-			plugin.WithAlwaysFallback(spec.AlwaysFallback),
+			plugin.WithAlwaysRunAll(spec.AlwaysRunAll),
 			plugin.WithMaxDepth(spec.MaxDepth),
 			plugin.WithServer(spec.Server),
 			plugin.WithAllowListFile(spec.AllowListFile),

--- a/cmd/drone-tree-config/main.go
+++ b/cmd/drone-tree-config/main.go
@@ -16,6 +16,7 @@ type (
 		AllowListFile       string        `envconfig:"PLUGIN_ALLOW_LIST_FILE"`
 		Concat              bool          `envconfig:"PLUGIN_CONCAT"`
 		MaxDepth            int           `envconfig:"PLUGIN_MAXDEPTH" default:"2"`
+		AlwaysFallback      bool          `envconfig:"PLUGIN_ALWAYS_FALLBACK"`
 		Fallback            bool          `envconfig:"PLUGIN_FALLBACK"`
 		Debug               bool          `envconfig:"PLUGIN_DEBUG"`
 		Address             string        `envconfig:"PLUGIN_ADDRESS" default:":3000"`
@@ -58,6 +59,7 @@ func main() {
 		plugin.New(
 			plugin.WithConcat(spec.Concat),
 			plugin.WithFallback(spec.Fallback),
+			plugin.WithAlwaysFallback(spec.AlwaysFallback),
 			plugin.WithMaxDepth(spec.MaxDepth),
 			plugin.WithServer(spec.Server),
 			plugin.WithAllowListFile(spec.AllowListFile),

--- a/plugin/options.go
+++ b/plugin/options.go
@@ -65,6 +65,13 @@ func WithFallback(fallback bool) func(*Plugin) {
 	}
 }
 
+// WithAlwaysFallback configures with always fallback enabled or disabled
+func WithAlwaysFallback(alwaysFallback bool) func(*Plugin) {
+	return func(p *Plugin) {
+		p.alwaysFallback = alwaysFallback
+	}
+}
+
 // WithMaxDepth configures with max depth to search for 'drone.yml'. Requires fallback to be enabled.
 func WithMaxDepth(maxDepth int) func(*Plugin) {
 	return func(p *Plugin) {

--- a/plugin/options.go
+++ b/plugin/options.go
@@ -65,10 +65,10 @@ func WithFallback(fallback bool) func(*Plugin) {
 	}
 }
 
-// WithAlwaysFallback configures with always fallback enabled or disabled
-func WithAlwaysFallback(alwaysFallback bool) func(*Plugin) {
+// WithAlwaysRunAll configures always run all enabled or disabled
+func WithAlwaysRunAll(alwaysRunAll bool) func(*Plugin) {
 	return func(p *Plugin) {
-		p.alwaysFallback = alwaysFallback
+		p.alwaysRunAll = alwaysRunAll
 	}
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -25,13 +25,14 @@ type (
 		bitBucketClient     string
 		bitBucketSecret     string
 
-		concat        bool
-		fallback      bool
-		maxDepth      int
-		allowListFile string
-		considerFile  string
-		cacheTTL      time.Duration
-		cache         *configCache
+		concat         bool
+		fallback       bool
+		alwaysFallback bool
+		maxDepth       int
+		allowListFile  string
+		considerFile   string
+		cacheTTL       time.Duration
+		cache          *configCache
 	}
 
 	droneConfig struct {
@@ -137,7 +138,14 @@ func (p *Plugin) getConfigData(ctx context.Context, req *request) (string, error
 
 	// get drone.yml for changed files or all of them if no changes/cron
 	configData := ""
-	if changedFiles != nil {
+
+	if p.alwaysFallback {
+		logrus.Warnf("%s always fallback enabled, rebuilding all", req.UUID)
+		if p.considerFile == "" {
+			logrus.Warnf("recursively scanning for config files with max depth %d", p.maxDepth)
+		}
+		configData, err = p.getConfigForTree(ctx, req, "", 0)
+	} else if changedFiles != nil {
 		configData, err = p.getConfigForChanges(ctx, req, changedFiles)
 	} else if req.Build.Trigger == "@cron" {
 		logrus.Warnf("%s @cron, rebuilding all", req.UUID)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -25,14 +25,14 @@ type (
 		bitBucketClient     string
 		bitBucketSecret     string
 
-		concat         bool
-		fallback       bool
-		alwaysFallback bool
-		maxDepth       int
-		allowListFile  string
-		considerFile   string
-		cacheTTL       time.Duration
-		cache          *configCache
+		concat        bool
+		fallback      bool
+		alwaysRunAll  bool
+		maxDepth      int
+		allowListFile string
+		considerFile  string
+		cacheTTL      time.Duration
+		cache         *configCache
 	}
 
 	droneConfig struct {
@@ -139,8 +139,8 @@ func (p *Plugin) getConfigData(ctx context.Context, req *request) (string, error
 	// get drone.yml for changed files or all of them if no changes/cron
 	configData := ""
 
-	if p.alwaysFallback {
-		logrus.Warnf("%s always fallback enabled, rebuilding all", req.UUID)
+	if p.alwaysRunAll {
+		logrus.Warnf("%s always run all enabled, rebuilding all", req.UUID)
 		if p.considerFile == "" {
 			logrus.Warnf("recursively scanning for config files with max depth %d", p.maxDepth)
 		}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -451,6 +451,67 @@ func TestCronConcat(t *testing.T) {
 		t.Errorf("Want\n  %q\ngot\n  %q", want, got)
 	}
 }
+func TestAlwaysFallback(t *testing.T) {
+	req := &config.Request{
+		Build: drone.Build{
+			Before: "2897b31ec3a1b59279a08a8ad54dc360686327f7",
+			After:  "8ecad91991d5da985a2a8dd97cc19029dc1c2899",
+			Source: "master",
+		},
+		Repo: drone.Repo{
+			Namespace: "foosinn",
+			Name:      "dronetest",
+			Slug:      "foosinn/dronetest",
+			Config:    ".drone.yml",
+		},
+	}
+	plugin := New(
+		WithServer(ts.URL),
+		WithGithubToken(mockToken),
+		WithAlwaysFallback(true),
+		WithMaxDepth(2),
+	)
+	droneConfig, err := plugin.Find(noContext, req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if want, got := "---\nkind: pipeline\nname: default\n\nsteps:\n- name: frontend\n  image: node\n  commands:\n  - npm install\n  - npm test\n\n- name: backend\n  image: golang\n  commands:\n  - go build\n  - go test\n", droneConfig.Data; want != got {
+		t.Errorf("Want\n  %q\ngot\n  %q", want, got)
+	}
+}
+func TestAlwaysFallbackConcat(t *testing.T) {
+	req := &config.Request{
+		Build: drone.Build{
+			Before: "2897b31ec3a1b59279a08a8ad54dc360686327f7",
+			After:  "8ecad91991d5da985a2a8dd97cc19029dc1c2899",
+			Source: "master",
+		},
+		Repo: drone.Repo{
+			Namespace: "foosinn",
+			Name:      "dronetest",
+			Slug:      "foosinn/dronetest",
+			Config:    ".drone.yml",
+		},
+	}
+	plugin := New(
+		WithServer(ts.URL),
+		WithGithubToken(mockToken),
+		WithConcat(true),
+		WithAlwaysFallback(true),
+		WithMaxDepth(2),
+	)
+	droneConfig, err := plugin.Find(noContext, req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if want, got := "---\nkind: pipeline\nname: default\n\nsteps:\n- name: frontend\n  image: node\n  commands:\n  - npm install\n  - npm test\n\n- name: backend\n  image: golang\n  commands:\n  - go build\n  - go test\n---\nkind: pipeline\nname: default\n\nsteps:\n- name: build\n  image: golang\n  commands:\n  - go build\n  - go test -short\n\n- name: integration\n  image: golang\n  commands:\n  - go test -v\n", droneConfig.Data; want != got {
+		t.Errorf("Want\n  %q\ngot\n  %q", want, got)
+	}
+}
 
 func TestStarlark(t *testing.T) {
 	req := &config.Request{

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -451,7 +451,7 @@ func TestCronConcat(t *testing.T) {
 		t.Errorf("Want\n  %q\ngot\n  %q", want, got)
 	}
 }
-func TestAlwaysFallback(t *testing.T) {
+func TestAlwaysRunAll(t *testing.T) {
 	req := &config.Request{
 		Build: drone.Build{
 			Before: "2897b31ec3a1b59279a08a8ad54dc360686327f7",
@@ -468,7 +468,7 @@ func TestAlwaysFallback(t *testing.T) {
 	plugin := New(
 		WithServer(ts.URL),
 		WithGithubToken(mockToken),
-		WithAlwaysFallback(true),
+		WithAlwaysRunAll(true),
 		WithMaxDepth(2),
 	)
 	droneConfig, err := plugin.Find(noContext, req)
@@ -481,7 +481,7 @@ func TestAlwaysFallback(t *testing.T) {
 		t.Errorf("Want\n  %q\ngot\n  %q", want, got)
 	}
 }
-func TestAlwaysFallbackConcat(t *testing.T) {
+func TestAlwaysRunAllConcat(t *testing.T) {
 	req := &config.Request{
 		Build: drone.Build{
 			Before: "2897b31ec3a1b59279a08a8ad54dc360686327f7",
@@ -499,7 +499,7 @@ func TestAlwaysFallbackConcat(t *testing.T) {
 		WithServer(ts.URL),
 		WithGithubToken(mockToken),
 		WithConcat(true),
-		WithAlwaysFallback(true),
+		WithAlwaysRunAll(true),
 		WithMaxDepth(2),
 	)
 	droneConfig, err := plugin.Find(noContext, req)


### PR DESCRIPTION
This PR adds ability for the plugin to always read through all available pipeline definition.

This feature is useful when a there needs to be pipeline dependencies between pipelines that are described in different pipeline definition yaml files.

For example repo structure:
```
 repository/
 ├── .drone,yml
 ├── foo
 │   ├── some_code.py
 │   └── .drone.yml
 ├── bar
 │   ├── some_other_code.py
 │   └── .drone.yml
```
root level `.drone,yml` defines a pipeline to build a golden image that should be reused by services `foo` and `bar`.
Pipeline for service `foo` has a declared dependency on a pipeline that builds the golden image.

When developer creates a PR by modifying the file `repository/foo/some_code.py`, this plugin only reads the `repository/foo/.drone.yml`.
And then the pipeline fails with the error:
> linter: invalid or unknown pipeline dependency

After enabling this feature `PLUGIN_ALWAYS_FALLBACK` - the plugin would also read `repository/drone,yml` (if `PLUGIN_CONCAT` is also enabled) and provide both of the pipelines to Drone.