### PR TITLE
Add consider repo config fallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Currently supports
 * `PLUGIN_SECRET`: Shared secret with drone. You can generate the token using `openssl rand -hex 16`.
 * `PLUGIN_ALLOW_LIST_FILE`: (Optional) Path to regex pattern file. Matches the repo slug(s) against a list of regex patterns. Defaults to `""`, match everything.
 * `PLUGIN_CACHE_TTL`: (Optional) Cache entry time to live value. When defined and greater than `0s`, enables in memory caching for request/response pairs.
-* `PLUGIN_CONSIDER_FILE`: (Optional) Consider file name. Only consider the `.drone.yml` files listed in this file. When defined, all enabled repos must contain a consider file.
+* `PLUGIN_CONSIDER_FILE`: (Optional) Consider file name. Only consider the `.drone.yml` files listed in this file. When defined, all enabled repos must contain a consider file unless `PLUGIN_CONSIDER_REPO_CONFIG=true`.
+* `PLUGIN_CONSIDER_REPO_CONFIG`: (Optional) If consider file does not exists, use the repository drone configuration as fallback.
 * `PLUGIN_FINALIZE`: Adds dependencies to all other pipelines to a user provider pipelined named `finalize`.
 
 Backend specific options

--- a/cmd/drone-tree-config/main.go
+++ b/cmd/drone-tree-config/main.go
@@ -30,6 +30,7 @@ type (
 		BitBucketClient     string        `envconfig:"BITBUCKET_CLIENT"`
 		BitBucketSecret     string        `envconfig:"BITBUCKET_SECRET"`
 		ConsiderFile        string        `envconfig:"PLUGIN_CONSIDER_FILE"`
+		ConsiderRepoConfig  bool          `envconfig:"PLUGIN_CONSIDER_REPO_CONFIG"`
 		CacheTTL            time.Duration `envconfig:"PLUGIN_CACHE_TTL"`
 	}
 )
@@ -71,6 +72,7 @@ func main() {
 			plugin.WithGitlabToken(spec.GitLabToken),
 			plugin.WithGitlabServer(spec.GitLabServer),
 			plugin.WithConsiderFile(spec.ConsiderFile),
+			plugin.WithConsiderRepoConfig(spec.ConsiderRepoConfig),
 			plugin.WithCacheTTL(spec.CacheTTL),
 		),
 		spec.Secret,

--- a/plugin/consider.go
+++ b/plugin/consider.go
@@ -33,6 +33,13 @@ func (p *Plugin) newConsiderDataFromRequest(ctx context.Context, req *request) (
 	// download considerFile from github
 	fc, err := p.getScmFile(ctx, req, p.considerFile)
 	if err != nil {
+		// use default drone config when the consider file doe not exists
+		if p.considerRepoConfig == true {
+			logrus.Infof("%s consider file %s is not present: falling back to repo config %s", req.UUID, p.considerFile, req.Repo.Config)
+			cd.listRepresentation = append(cd.listRepresentation, req.Repo.Config)
+			cd.mapRepresentation[req.Repo.Config] = true
+			return cd, nil
+		}
 		logrus.Errorf("%s skipping: %s is not present: %v", req.UUID, p.considerFile, err)
 		return cd, err
 	}

--- a/plugin/options.go
+++ b/plugin/options.go
@@ -101,6 +101,13 @@ func WithConsiderFile(considerFile string) func(*Plugin) {
 	}
 }
 
+// WithConsiderRepoConfig enable fallback to the repository 'drone.yml' when a consider file is configured but not found.
+func WithConsiderRepoConfig(considerRepoConfig bool) func(*Plugin) {
+	return func(p *Plugin) {
+		p.considerRepoConfig = considerRepoConfig
+	}
+}
+
 // WithCacheTTL enables request/response caching and the specified TTL for each entry
 func WithCacheTTL(ttl time.Duration) func(*Plugin) {
 	return func(p *Plugin) {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -26,15 +26,16 @@ type (
 		bitBucketClient     string
 		bitBucketSecret     string
 
-		concat        bool
-		fallback      bool
-		alwaysRunAll  bool
-		finalize      bool
-		maxDepth      int
-		allowListFile string
-		considerFile  string
-		cacheTTL      time.Duration
-		cache         *configCache
+		concat             bool
+		fallback           bool
+		alwaysRunAll       bool
+		finalize           bool
+		maxDepth           int
+		allowListFile      string
+		considerFile       string
+		considerRepoConfig bool
+		cacheTTL           time.Duration
+		cache              *configCache
 	}
 
 	droneConfig struct {


### PR DESCRIPTION
# Repo config fallback option when `consider file` is not found

The [consider file](https://github.com/bitsbeats/drone-tree-config/pull/32) feature is great, but you must set a configure file in all your repositories, whether it's a mono-repo or not.
With many repositories (mono-repo and standard repo), this can be tedious. We went into this issue while refactoring our codebase into mono-repos.

This PR adds the option `PLUGIN_CONSIDER_REPO_CONFIG` to allow falling back to the drone configuration of the repository when the server defines a `PLUGIN_CONSIDER_FILE` but the repository does not have one.
